### PR TITLE
fix: add generic type annotation to `registerSingleton()` call

### DIFF
--- a/injectable/lib/src/get_it_helper.dart
+++ b/injectable/lib/src/get_it_helper.dart
@@ -215,7 +215,7 @@ class GetItHelper {
     if (_canRegister(registerFor)) {
       if (preResolve) {
         return factoryFunc().then(
-          (instance) => getIt.registerSingleton(
+          (instance) => getIt.registerSingleton<T>(
             instance,
             instanceName: instanceName,
             signalsReady: signalsReady,


### PR DESCRIPTION
This fixes the now (from Dart SDK 3 onwards required) generic type annotation when calling `registerSingleton` from GetIt. Check the following issue:  https://github.com/fluttercommunity/get_it/issues/331#issuecomment-1565293277